### PR TITLE
update schema to include hexadecimal letter ID's

### DIFF
--- a/compiled-ODD/guidelines-de-wegaBiblio.compiled.xml
+++ b/compiled-ODD/guidelines-de-wegaBiblio.compiled.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/pstadler/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
+<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/steffenastheimer/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
         24th January 2025, revision f73186978?>
 	<teiHeader><fileDesc>
 			<titleStmt>
@@ -4929,10 +4929,10 @@ which contain an XPath expression.</desc>
                         <sch:assert test="matches(@key, '^(A03\d{4}\s)*A03\d{4}$')">A type value of 'writings' must have at least one key, each starting with 'A03'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letter'][@key]">
-                        <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letters'][@key]">
-                        <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='news'][@key]">
                         <sch:assert test="matches(@key, '^(A05\d{4}\s)*A05\d{4}$')">A type value of 'news' must have at least one key, starting with 'A05'</sch:assert>
@@ -6594,7 +6594,7 @@ element is appropriate for which circumstance.</p>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für Brief-IDs innerhalb der WeGA</desc>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="en" versionDate="2017-08-29">defines the possible attribute values for letter IDs within the WeGA</desc>
             <content xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0">
-                <dataRef name="string" restriction="A04\d{4}"/>
+                <dataRef name="string" restriction="A04[0-9A-F]{4}"/>
             </content>
         </dataSpec><dataSpec rend="add" ident="wega.news.pointer" mode="add" module="wega.core.module">
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für News-IDs innerhalb der WeGA</desc>

--- a/compiled-ODD/guidelines-de-wegaDiaries.compiled.xml
+++ b/compiled-ODD/guidelines-de-wegaDiaries.compiled.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/pstadler/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
+<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/steffenastheimer/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
         24th January 2025, revision f73186978?>
 	<teiHeader><fileDesc>
 			<titleStmt>
@@ -6799,10 +6799,10 @@ concerned, as further discussed in section <ref target="https://www.tei-c.org/re
                         <sch:assert test="matches(@key, '^(A03\d{4}\s)*A03\d{4}$')">A type value of 'writings' must have at least one key, each starting with 'A03'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letter'][@key]">
-                        <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letters'][@key]">
-                        <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='news'][@key]">
                         <sch:assert test="matches(@key, '^(A05\d{4}\s)*A05\d{4}$')">A type value of 'news' must have at least one key, starting with 'A05'</sch:assert>
@@ -11179,7 +11179,7 @@ element is appropriate for which circumstance.</p>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für Brief-IDs innerhalb der WeGA</desc>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="en" versionDate="2017-08-29">defines the possible attribute values for letter IDs within the WeGA</desc>
             <content xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0">
-                <dataRef name="string" restriction="A04\d{4}"/>
+                <dataRef name="string" restriction="A04[0-9A-F]{4}"/>
             </content>
         </dataSpec><dataSpec rend="add" ident="wega.news.pointer" mode="add" module="wega.core.module">
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für News-IDs innerhalb der WeGA</desc>

--- a/compiled-ODD/guidelines-de-wegaDocuments.compiled.xml
+++ b/compiled-ODD/guidelines-de-wegaDocuments.compiled.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/pstadler/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
+<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/steffenastheimer/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
         24th January 2025, revision f73186978?>
 	<teiHeader><fileDesc>
 			<titleStmt>
@@ -6764,10 +6764,10 @@ concerned, as further discussed in section <ref target="https://www.tei-c.org/re
                         <sch:assert test="matches(@key, '^(A03\d{4}\s)*A03\d{4}$')">A type value of 'writings' must have at least one key, each starting with 'A03'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letter'][@key]">
-                        <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letters'][@key]">
-                        <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='news'][@key]">
                         <sch:assert test="matches(@key, '^(A05\d{4}\s)*A05\d{4}$')">A type value of 'news' must have at least one key, starting with 'A05'</sch:assert>
@@ -15935,7 +15935,7 @@ may be empty.</p>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für Brief-IDs innerhalb der WeGA</desc>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="en" versionDate="2017-08-29">defines the possible attribute values for letter IDs within the WeGA</desc>
             <content xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0">
-                <dataRef name="string" restriction="A04\d{4}"/>
+                <dataRef name="string" restriction="A04[0-9A-F]{4}"/>
             </content>
         </dataSpec><dataSpec rend="add" ident="wega.news.pointer" mode="add" module="wega.core.module">
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für News-IDs innerhalb der WeGA</desc>

--- a/compiled-ODD/guidelines-de-wegaLetters.compiled.xml
+++ b/compiled-ODD/guidelines-de-wegaLetters.compiled.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/pstadler/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
+<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/steffenastheimer/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
         24th January 2025, revision f73186978?>
 	<teiHeader><fileDesc>
 			<titleStmt>
@@ -6945,10 +6945,10 @@ concerned, as further discussed in section <ref target="https://www.tei-c.org/re
                         <sch:assert test="matches(@key, '^(A03\d{4}\s)*A03\d{4}$')">A type value of 'writings' must have at least one key, each starting with 'A03'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letter'][@key]">
-                        <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letters'][@key]">
-                        <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='news'][@key]">
                         <sch:assert test="matches(@key, '^(A05\d{4}\s)*A05\d{4}$')">A type value of 'news' must have at least one key, starting with 'A05'</sch:assert>
@@ -16718,7 +16718,7 @@ may be empty.</p>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für Brief-IDs innerhalb der WeGA</desc>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="en" versionDate="2017-08-29">defines the possible attribute values for letter IDs within the WeGA</desc>
             <content xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0">
-                <dataRef name="string" restriction="A04\d{4}"/>
+                <dataRef name="string" restriction="A04[0-9A-F]{4}"/>
             </content>
         </dataSpec><dataSpec rend="add" ident="wega.news.pointer" mode="add" module="wega.core.module">
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für News-IDs innerhalb der WeGA</desc>

--- a/compiled-ODD/guidelines-de-wegaNews.compiled.xml
+++ b/compiled-ODD/guidelines-de-wegaNews.compiled.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/pstadler/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
+<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/steffenastheimer/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
         24th January 2025, revision f73186978?>
 	<teiHeader><fileDesc>
 			<titleStmt>
@@ -5487,10 +5487,10 @@ one initial.</desc>
                         <sch:assert test="matches(@key, '^(A03\d{4}\s)*A03\d{4}$')">A type value of 'writings' must have at least one key, each starting with 'A03'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letter'][@key]">
-                        <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letters'][@key]">
-                        <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='news'][@key]">
                         <sch:assert test="matches(@key, '^(A05\d{4}\s)*A05\d{4}$')">A type value of 'news' must have at least one key, starting with 'A05'</sch:assert>
@@ -9947,7 +9947,7 @@ purposes.</p>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für Brief-IDs innerhalb der WeGA</desc>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="en" versionDate="2017-08-29">defines the possible attribute values for letter IDs within the WeGA</desc>
             <content xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0">
-                <dataRef name="string" restriction="A04\d{4}"/>
+                <dataRef name="string" restriction="A04[0-9A-F]{4}"/>
             </content>
         </dataSpec><dataSpec rend="add" ident="wega.news.pointer" mode="add" module="wega.core.module">
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für News-IDs innerhalb der WeGA</desc>

--- a/compiled-ODD/guidelines-de-wegaOrgs.compiled.xml
+++ b/compiled-ODD/guidelines-de-wegaOrgs.compiled.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/pstadler/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
+<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/steffenastheimer/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
         24th January 2025, revision f73186978?>
 	<teiHeader><fileDesc>
 			<titleStmt>
@@ -5825,10 +5825,10 @@ one initial.</desc>
                         <sch:assert test="matches(@key, '^(A03\d{4}\s)*A03\d{4}$')">A type value of 'writings' must have at least one key, each starting with 'A03'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letter'][@key]">
-                        <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letters'][@key]">
-                        <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='news'][@key]">
                         <sch:assert test="matches(@key, '^(A05\d{4}\s)*A05\d{4}$')">A type value of 'news' must have at least one key, starting with 'A05'</sch:assert>
@@ -9701,7 +9701,7 @@ element is appropriate for which circumstance.</p>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für Brief-IDs innerhalb der WeGA</desc>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="en" versionDate="2017-08-29">defines the possible attribute values for letter IDs within the WeGA</desc>
             <content xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0">
-                <dataRef name="string" restriction="A04\d{4}"/>
+                <dataRef name="string" restriction="A04[0-9A-F]{4}"/>
             </content>
         </dataSpec><dataSpec rend="add" ident="wega.news.pointer" mode="add" module="wega.core.module">
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für News-IDs innerhalb der WeGA</desc>

--- a/compiled-ODD/guidelines-de-wegaPersons.compiled.xml
+++ b/compiled-ODD/guidelines-de-wegaPersons.compiled.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/pstadler/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
+<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/steffenastheimer/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
         24th January 2025, revision f73186978?>
 	<teiHeader><fileDesc>
 			<titleStmt>
@@ -5600,10 +5600,10 @@ one initial.</desc>
                         <sch:assert test="matches(@key, '^(A03\d{4}\s)*A03\d{4}$')">A type value of 'writings' must have at least one key, each starting with 'A03'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letter'][@key]">
-                        <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letters'][@key]">
-                        <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='news'][@key]">
                         <sch:assert test="matches(@key, '^(A05\d{4}\s)*A05\d{4}$')">A type value of 'news' must have at least one key, starting with 'A05'</sch:assert>
@@ -8441,7 +8441,7 @@ element is appropriate for which circumstance.</p>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für Brief-IDs innerhalb der WeGA</desc>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="en" versionDate="2017-08-29">defines the possible attribute values for letter IDs within the WeGA</desc>
             <content xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0">
-                <dataRef name="string" restriction="A04\d{4}"/>
+                <dataRef name="string" restriction="A04[0-9A-F]{4}"/>
             </content>
         </dataSpec><dataSpec rend="add" ident="wega.news.pointer" mode="add" module="wega.core.module">
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für News-IDs innerhalb der WeGA</desc>

--- a/compiled-ODD/guidelines-de-wegaPlaces.compiled.xml
+++ b/compiled-ODD/guidelines-de-wegaPlaces.compiled.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/pstadler/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
+<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/steffenastheimer/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
         24th January 2025, revision f73186978?>
 	<teiHeader><fileDesc>
 			<titleStmt>
@@ -5088,10 +5088,10 @@ which contain an XPath expression.</desc>
                         <sch:assert test="matches(@key, '^(A03\d{4}\s)*A03\d{4}$')">A type value of 'writings' must have at least one key, each starting with 'A03'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letter'][@key]">
-                        <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letters'][@key]">
-                        <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='news'][@key]">
                         <sch:assert test="matches(@key, '^(A05\d{4}\s)*A05\d{4}$')">A type value of 'news' must have at least one key, starting with 'A05'</sch:assert>
@@ -6921,7 +6921,7 @@ psychological significance.
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für Brief-IDs innerhalb der WeGA</desc>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="en" versionDate="2017-08-29">defines the possible attribute values for letter IDs within the WeGA</desc>
             <content xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0">
-                <dataRef name="string" restriction="A04\d{4}"/>
+                <dataRef name="string" restriction="A04[0-9A-F]{4}"/>
             </content>
         </dataSpec><dataSpec rend="add" ident="wega.news.pointer" mode="add" module="wega.core.module">
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für News-IDs innerhalb der WeGA</desc>

--- a/compiled-ODD/guidelines-de-wegaSourcesTEI.compiled.xml
+++ b/compiled-ODD/guidelines-de-wegaSourcesTEI.compiled.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/pstadler/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
+<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/steffenastheimer/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
         24th January 2025, revision f73186978?>
 	<teiHeader><fileDesc>
 			<titleStmt>
@@ -7438,10 +7438,10 @@ concerned, as further discussed in section <ref target="https://www.tei-c.org/re
                         <sch:assert test="matches(@key, '^(A03\d{4}\s)*A03\d{4}$')">A type value of 'writings' must have at least one key, each starting with 'A03'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letter'][@key]">
-                        <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letters'][@key]">
-                        <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='news'][@key]">
                         <sch:assert test="matches(@key, '^(A05\d{4}\s)*A05\d{4}$')">A type value of 'news' must have at least one key, starting with 'A05'</sch:assert>
@@ -17402,7 +17402,7 @@ institution.</desc><desc versionDate="2007-12-20" xml:lang="ko">원고 또는 �
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für Brief-IDs innerhalb der WeGA</desc>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="en" versionDate="2017-08-29">defines the possible attribute values for letter IDs within the WeGA</desc>
             <content xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0">
-                <dataRef name="string" restriction="A04\d{4}"/>
+                <dataRef name="string" restriction="A04[0-9A-F]{4}"/>
             </content>
         </dataSpec><dataSpec rend="add" ident="wega.news.pointer" mode="add" module="wega.core.module">
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für News-IDs innerhalb der WeGA</desc>

--- a/compiled-ODD/guidelines-de-wegaThematicCommentaries.compiled.xml
+++ b/compiled-ODD/guidelines-de-wegaThematicCommentaries.compiled.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/pstadler/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
+<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/steffenastheimer/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
         24th January 2025, revision f73186978?>
 	<teiHeader><fileDesc>
 			<titleStmt>
@@ -6294,10 +6294,10 @@ concerned, as further discussed in section <ref target="https://www.tei-c.org/re
                         <sch:assert test="matches(@key, '^(A03\d{4}\s)*A03\d{4}$')">A type value of 'writings' must have at least one key, each starting with 'A03'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letter'][@key]">
-                        <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letters'][@key]">
-                        <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='news'][@key]">
                         <sch:assert test="matches(@key, '^(A05\d{4}\s)*A05\d{4}$')">A type value of 'news' must have at least one key, starting with 'A05'</sch:assert>
@@ -13872,7 +13872,7 @@ references must be used to represent the markup delimiters. If the
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für Brief-IDs innerhalb der WeGA</desc>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="en" versionDate="2017-08-29">defines the possible attribute values for letter IDs within the WeGA</desc>
             <content xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0">
-                <dataRef name="string" restriction="A04\d{4}"/>
+                <dataRef name="string" restriction="A04[0-9A-F]{4}"/>
             </content>
         </dataSpec><dataSpec rend="add" ident="wega.news.pointer" mode="add" module="wega.core.module">
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für News-IDs innerhalb der WeGA</desc>

--- a/compiled-ODD/guidelines-de-wegaVar.compiled.xml
+++ b/compiled-ODD/guidelines-de-wegaVar.compiled.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/pstadler/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
+<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/steffenastheimer/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
         24th January 2025, revision f73186978?>
 	<teiHeader><fileDesc>
 			<titleStmt>
@@ -6440,10 +6440,10 @@ concerned, as further discussed in section <ref target="https://www.tei-c.org/re
                         <sch:assert test="matches(@key, '^(A03\d{4}\s)*A03\d{4}$')">A type value of 'writings' must have at least one key, each starting with 'A03'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letter'][@key]">
-                        <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letters'][@key]">
-                        <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='news'][@key]">
                         <sch:assert test="matches(@key, '^(A05\d{4}\s)*A05\d{4}$')">A type value of 'news' must have at least one key, starting with 'A05'</sch:assert>
@@ -14548,7 +14548,7 @@ used to mark normal inter-word space or the like.</p>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für Brief-IDs innerhalb der WeGA</desc>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="en" versionDate="2017-08-29">defines the possible attribute values for letter IDs within the WeGA</desc>
             <content xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0">
-                <dataRef name="string" restriction="A04\d{4}"/>
+                <dataRef name="string" restriction="A04[0-9A-F]{4}"/>
             </content>
         </dataSpec><dataSpec rend="add" ident="wega.news.pointer" mode="add" module="wega.core.module">
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für News-IDs innerhalb der WeGA</desc>

--- a/compiled-ODD/guidelines-de-wegaWorks.compiled.xml
+++ b/compiled-ODD/guidelines-de-wegaWorks.compiled.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/pstadler/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION Version 5.0?>
+<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/steffenastheimer/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION Version 5.0?>
 	<teiHeader><fileDesc>
 			<titleStmt>
 				<title>Editionsrichtlinien Text der WeGA</title>
@@ -256,6 +256,33 @@
                                 </imprint>
                             </monogr>
                         </biblStruct></egXML>
+                <egXML xmlns="http://www.tei-c.org/ns/Examples" source="A112512">
+                    <biblStruct xml:id="A112512" status="candidate" type="article">
+                        <analytic>
+                            <author key="A000288">Helmina von Chézy</author>
+                            <title level="a">Carl Maria von Weber's Euryanthe. Ein Beitrag zur Geschichte der deutschen Oper, von Helmina v. Chezy, geb. Freiin Klencke</title>
+                            <idno type="WeGA">A031868</idno>
+                            <idno type="WeGA">A031757</idno>
+                            <idno type="WeGA">A031897</idno>
+                            <idno type="WeGA">A031534</idno>
+                            <idno type="WeGA">A031842</idno>
+                            <idno type="WeGA">A031984</idno>
+                            <idno type="WeGA">A031927</idno>
+                            <idno type="WeGA">A031880</idno>
+                            <idno type="WeGA">A031903</idno>
+                        </analytic>
+                        <monogr>
+                            <title level="j">Neue Zeitschrift für Musik</title>
+                            <imprint>
+                                <biblScope unit="jg">7</biblScope>
+                                <biblScope unit="vol">13</biblScope>
+                                <biblScope unit="nr">1–11</biblScope>
+                                <date when="1840">Juli-August 1840</date>
+                                <biblScope unit="pp">1–2, 5–6, 9–10, 13–14, 17–19, 21–22, 33–35, 37–39, 41–43</biblScope>
+                            </imprint>
+                        </monogr>
+                    </biblStruct>
+                </egXML>
             </p>
         </div>
         <div xml:id="DT-works">
@@ -1120,7 +1147,7 @@
 				
 				
 				
-				<schemaSpec xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:sch="http://purl.oclc.org/dsdl/schematron" ident="wegaWorks" xml:lang="en" ns="http://www.music-encoding.org/ns/mei" start="mei manifestation" xml:base="../Specs/schemaSpec-works.odd.xml" source="/Users/pstadler/static/music-encoding-5.0/mei-source_canonicalized.xml"><macroSpec rend="add" ident="data.ACCIDENTAL.WRITTEN" module="MEI" type="dt">
+				<schemaSpec xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:sch="http://purl.oclc.org/dsdl/schematron" ident="wegaWorks" xml:lang="en" ns="http://www.music-encoding.org/ns/mei" start="mei manifestation" xml:base="../Specs/schemaSpec-works.odd.xml" source="/Users/steffenastheimer/static/music-encoding-5.0/mei-source_canonicalized.xml"><macroSpec rend="add" ident="data.ACCIDENTAL.WRITTEN" module="MEI" type="dt">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Written accidental values.</desc>
     <content xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <alternate minOccurs="1" maxOccurs="1"><macroRef key="data.ACCIDENTAL.WRITTEN.basic"/><macroRef key="data.ACCIDENTAL.WRITTEN.extended"/><macroRef key="data.ACCIDENTAL.aeu"/><macroRef key="data.ACCIDENTAL.persian"/></alternate>
@@ -6727,7 +6754,7 @@
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für Brief-IDs innerhalb der WeGA</desc>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="en" versionDate="2017-08-29">defines the possible attribute values for letter IDs within the WeGA</desc>
             <content xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0">
-                <dataRef name="string" restriction="A04\d{4}"/>
+                <dataRef name="string" restriction="A04[0-9A-F]{4}"/>
             </content>
         </dataSpec><dataSpec rend="add" ident="wega.news.pointer" mode="add" module="wega.core.module">
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für News-IDs innerhalb der WeGA</desc>

--- a/compiled-ODD/guidelines-de-wegaWritings.compiled.xml
+++ b/compiled-ODD/guidelines-de-wegaWritings.compiled.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/pstadler/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
+<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/steffenastheimer/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
         24th January 2025, revision f73186978?>
 	<teiHeader><fileDesc>
 			<titleStmt>
@@ -6695,10 +6695,10 @@ concerned, as further discussed in section <ref target="https://www.tei-c.org/re
                         <sch:assert test="matches(@key, '^(A03\d{4}\s)*A03\d{4}$')">A type value of 'writings' must have at least one key, each starting with 'A03'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letter'][@key]">
-                        <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letters'][@key]">
-                        <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='news'][@key]">
                         <sch:assert test="matches(@key, '^(A05\d{4}\s)*A05\d{4}$')">A type value of 'news' must have at least one key, starting with 'A05'</sch:assert>
@@ -15528,7 +15528,7 @@ may be empty.</p>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für Brief-IDs innerhalb der WeGA</desc>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="en" versionDate="2017-08-29">defines the possible attribute values for letter IDs within the WeGA</desc>
             <content xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0">
-                <dataRef name="string" restriction="A04\d{4}"/>
+                <dataRef name="string" restriction="A04[0-9A-F]{4}"/>
             </content>
         </dataSpec><dataSpec rend="add" ident="wega.news.pointer" mode="add" module="wega.core.module">
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für News-IDs innerhalb der WeGA</desc>

--- a/compiled-ODD/guidelines-de-wega_all.compiled.xml
+++ b/compiled-ODD/guidelines-de-wega_all.compiled.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/pstadler/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
+<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xml:base="file:/Users/steffenastheimer/repos/WeGA-ODD/src/Guidelines/guidelines-de.xml" xml:lang="de"><?TEIVERSION P5 Version 4.9.0. Last updated on
         24th January 2025, revision f73186978?>
 	<teiHeader><fileDesc>
 			<titleStmt>
@@ -8231,10 +8231,10 @@ concerned, as further discussed in section <ref target="https://www.tei-c.org/re
                         <sch:assert test="matches(@key, '^(A03\d{4}\s)*A03\d{4}$')">A type value of 'writings' must have at least one key, each starting with 'A03'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letter'][@key]">
-                        <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letters'][@key]">
-                        <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='news'][@key]">
                         <sch:assert test="matches(@key, '^(A05\d{4}\s)*A05\d{4}$')">A type value of 'news' must have at least one key, starting with 'A05'</sch:assert>
@@ -21368,7 +21368,7 @@ element is appropriate for which circumstance.</p>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für Brief-IDs innerhalb der WeGA</desc>
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="en" versionDate="2017-08-29">defines the possible attribute values for letter IDs within the WeGA</desc>
             <content xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0">
-                <dataRef name="string" restriction="A04\d{4}"/>
+                <dataRef name="string" restriction="A04[0-9A-F]{4}"/>
             </content>
         </dataSpec><dataSpec rend="add" ident="wega.news.pointer" mode="add" module="wega.core.module">
             <desc xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:tei="http://www.tei-c.org/ns/1.0" xml:lang="de" versionDate="2017-08-29">definiert das Muster für News-IDs innerhalb der WeGA</desc>

--- a/schema/de/wegaBiblio.isosch
+++ b/schema/de/wegaBiblio.isosch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <title>ISO Schematron rules</title>
-   <!-- This file generated 2025-06-26T14:13:57Z by 'extract-isosch.xsl'. -->
+   <!-- This file generated 2025-07-09T08:33:24Z by 'extract-isosch.xsl'. -->
    <!-- ********************* -->
    <!-- namespaces, declared: -->
    <!-- ********************* -->
@@ -119,12 +119,12 @@
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-21">
       <rule context="tei:rs[@type='letter'][@key]">
-         <assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
+         <assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-22">
       <rule context="tei:rs[@type='letters'][@key]">
-         <assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
+         <assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-23">

--- a/schema/de/wegaBiblio.rng
+++ b/schema/de/wegaBiblio.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-06-26T14:13:57Z. . 
+Schema generated from ODD source 2025-07-09T08:33:24Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -1621,7 +1621,7 @@ Empfohlene Werte sind: 1] spoken (spoken); 2] thought (thought); 3] written (wri
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -1629,7 +1629,7 @@ Empfohlene Werte sind: 1] spoken (spoken); 2] thought (thought); 3] written (wri
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -1790,7 +1790,7 @@ Empfohlene Werte sind: 1] spoken (spoken); 2] thought (thought); 3] written (wri
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/de/wegaDiaries.isosch
+++ b/schema/de/wegaDiaries.isosch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <title>ISO Schematron rules</title>
-   <!-- This file generated 2025-03-18T07:58:24Z by 'extract-isosch.xsl'. -->
+   <!-- This file generated 2025-07-09T08:33:32Z by 'extract-isosch.xsl'. -->
    <!-- ********************* -->
    <!-- namespaces, declared: -->
    <!-- ********************* -->
@@ -159,12 +159,12 @@
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-29">
       <rule context="tei:rs[@type='letter'][@key]">
-         <assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
+         <assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-30">
       <rule context="tei:rs[@type='letters'][@key]">
-         <assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
+         <assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-31">

--- a/schema/de/wegaDiaries.rng
+++ b/schema/de/wegaDiaries.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-03-18T07:58:24Z. . 
+Schema generated from ODD source 2025-07-09T08:33:32Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -2715,7 +2715,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2723,7 +2723,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2884,7 +2884,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>
@@ -4733,7 +4733,7 @@ Beispielwerte sind etwa: 1] glued; 2] pinned; 3] sewn</a:documentation>
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/de/wegaDocuments.isosch
+++ b/schema/de/wegaDocuments.isosch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <title>ISO Schematron rules</title>
-   <!-- This file generated 2025-06-26T14:13:59Z by 'extract-isosch.xsl'. -->
+   <!-- This file generated 2025-07-09T08:33:35Z by 'extract-isosch.xsl'. -->
    <!-- ********************* -->
    <!-- namespaces, declared: -->
    <!-- ********************* -->
@@ -154,12 +154,12 @@
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-28">
       <rule context="tei:rs[@type='letter'][@key]">
-         <assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
+         <assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-29">
       <rule context="tei:rs[@type='letters'][@key]">
-         <assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
+         <assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-30">

--- a/schema/de/wegaDocuments.rng
+++ b/schema/de/wegaDocuments.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-06-26T14:13:58Z. . 
+Schema generated from ODD source 2025-07-09T08:33:35Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -3166,7 +3166,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3174,7 +3174,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3335,7 +3335,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>
@@ -5397,7 +5397,7 @@ Empfohlene Werte sind: 1] ISBN; 2] ISSN; 3] DOI; 4] URI; 5] VIAF; 6] ESTC; 7] OC
                         <param name="pattern">A03\d{4}</param>
                      </data>
                      <data type="string">
-                        <param name="pattern">A04\d{4}</param>
+                        <param name="pattern">A04[0-9A-F]{4}</param>
                      </data>
                      <data type="string">
                         <param name="pattern">A10\d{4}</param>
@@ -6964,7 +6964,7 @@ Beispielwerte sind etwa: 1] glued; 2] pinned; 3] sewn</a:documentation>
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/de/wegaLetters.isosch
+++ b/schema/de/wegaLetters.isosch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <title>ISO Schematron rules</title>
-   <!-- This file generated 2025-03-18T07:58:25Z by 'extract-isosch.xsl'. -->
+   <!-- This file generated 2025-07-09T08:33:38Z by 'extract-isosch.xsl'. -->
    <!-- ********************* -->
    <!-- namespaces, declared: -->
    <!-- ********************* -->
@@ -154,12 +154,12 @@
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-28">
       <rule context="tei:rs[@type='letter'][@key]">
-         <assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
+         <assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-29">
       <rule context="tei:rs[@type='letters'][@key]">
-         <assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
+         <assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-30">

--- a/schema/de/wegaLetters.rng
+++ b/schema/de/wegaLetters.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-06-26T14:13:59Z. . 
+Schema generated from ODD source 2025-07-09T08:33:37Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -3305,7 +3305,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3313,7 +3313,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3474,7 +3474,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>
@@ -5701,7 +5701,7 @@ Empfohlene Werte sind: 1] sent; 2] received; 3] transmitted; 4] redirected; 5] f
                         <param name="pattern">A03\d{4}</param>
                      </data>
                      <data type="string">
-                        <param name="pattern">A04\d{4}</param>
+                        <param name="pattern">A04[0-9A-F]{4}</param>
                      </data>
                      <data type="string">
                         <param name="pattern">A10\d{4}</param>
@@ -5715,7 +5715,7 @@ Empfohlene Werte sind: 1] sent; 2] received; 3] transmitted; 4] redirected; 5] f
          <attribute name="xml:id">
             <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Bezeichner) liefert einen eindeutigen Bezeichner für das Element mit dem Attribut.</a:documentation>
             <data type="string">
-               <param name="pattern">A04\d{4}</param>
+               <param name="pattern">A04[0-9A-F]{4}</param>
             </data>
          </attribute>
          <empty/>
@@ -7531,7 +7531,7 @@ Beispielwerte sind etwa: 1] glued; 2] pinned; 3] sewn</a:documentation>
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/de/wegaNews.isosch
+++ b/schema/de/wegaNews.isosch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <title>ISO Schematron rules</title>
-   <!-- This file generated 2025-03-18T07:58:26Z by 'extract-isosch.xsl'. -->
+   <!-- This file generated 2025-07-09T08:33:39Z by 'extract-isosch.xsl'. -->
    <!-- ********************* -->
    <!-- namespaces, declared: -->
    <!-- ********************* -->
@@ -124,12 +124,12 @@
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-22">
       <rule context="tei:rs[@type='letter'][@key]">
-         <assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
+         <assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-23">
       <rule context="tei:rs[@type='letters'][@key]">
-         <assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
+         <assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-24">

--- a/schema/de/wegaNews.rng
+++ b/schema/de/wegaNews.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-03-18T07:58:26Z. . 
+Schema generated from ODD source 2025-07-09T08:33:39Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -2255,7 +2255,7 @@ Empfohlene Werte sind: 1] spoken (spoken); 2] thought (thought); 3] written (wri
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2263,7 +2263,7 @@ Empfohlene Werte sind: 1] spoken (spoken); 2] thought (thought); 3] written (wri
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2424,7 +2424,7 @@ Empfohlene Werte sind: 1] spoken (spoken); 2] thought (thought); 3] written (wri
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/de/wegaOrgs.isosch
+++ b/schema/de/wegaOrgs.isosch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <title>ISO Schematron rules</title>
-   <!-- This file generated 2025-03-18T07:58:27Z by 'extract-isosch.xsl'. -->
+   <!-- This file generated 2025-07-09T08:33:40Z by 'extract-isosch.xsl'. -->
    <!-- ********************* -->
    <!-- namespaces, declared: -->
    <!-- ********************* -->
@@ -134,12 +134,12 @@
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-24">
       <rule context="tei:rs[@type='letter'][@key]">
-         <assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
+         <assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-25">
       <rule context="tei:rs[@type='letters'][@key]">
-         <assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
+         <assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-26">

--- a/schema/de/wegaOrgs.rng
+++ b/schema/de/wegaOrgs.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-03-18T07:58:27Z. . 
+Schema generated from ODD source 2025-07-09T08:33:40Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -2463,7 +2463,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       xmlns:xi="http://www.w3.org/2001/XInclude"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2472,7 +2472,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       xmlns:xi="http://www.w3.org/2001/XInclude"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2645,7 +2645,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>
@@ -4414,7 +4414,7 @@ Elements 7.2.5. Speech Contents]</a:documentation>
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/de/wegaPersons.isosch
+++ b/schema/de/wegaPersons.isosch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <title>ISO Schematron rules</title>
-   <!-- This file generated 2025-03-18T07:58:27Z by 'extract-isosch.xsl'. -->
+   <!-- This file generated 2025-07-09T08:33:47Z by 'extract-isosch.xsl'. -->
    <!-- ********************* -->
    <!-- namespaces, declared: -->
    <!-- ********************* -->
@@ -124,12 +124,12 @@
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-22">
       <rule context="tei:rs[@type='letter'][@key]">
-         <assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
+         <assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-23">
       <rule context="tei:rs[@type='letters'][@key]">
-         <assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
+         <assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-24">

--- a/schema/de/wegaPersons.rng
+++ b/schema/de/wegaPersons.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-03-18T07:58:27Z. . 
+Schema generated from ODD source 2025-07-09T08:33:47Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -2221,7 +2221,7 @@ Empfohlene Werte sind: 1] spoken (spoken); 2] thought (thought); 3] written (wri
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2229,7 +2229,7 @@ Empfohlene Werte sind: 1] spoken (spoken); 2] thought (thought); 3] written (wri
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2390,7 +2390,7 @@ Empfohlene Werte sind: 1] spoken (spoken); 2] thought (thought); 3] written (wri
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/de/wegaPlaces.isosch
+++ b/schema/de/wegaPlaces.isosch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <title>ISO Schematron rules</title>
-   <!-- This file generated 2025-03-18T07:58:28Z by 'extract-isosch.xsl'. -->
+   <!-- This file generated 2025-07-09T08:33:50Z by 'extract-isosch.xsl'. -->
    <!-- ********************* -->
    <!-- namespaces, declared: -->
    <!-- ********************* -->
@@ -124,12 +124,12 @@
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-22">
       <rule context="tei:rs[@type='letter'][@key]">
-         <assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
+         <assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-23">
       <rule context="tei:rs[@type='letters'][@key]">
-         <assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
+         <assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-24">

--- a/schema/de/wegaPlaces.rng
+++ b/schema/de/wegaPlaces.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-06-26T14:14:01Z. . 
+Schema generated from ODD source 2025-07-09T08:33:49Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -2003,7 +2003,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2011,7 +2011,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2172,7 +2172,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/de/wegaSourcesTEI.isosch
+++ b/schema/de/wegaSourcesTEI.isosch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <title>ISO Schematron rules</title>
-   <!-- This file generated 2025-03-18T07:58:28Z by 'extract-isosch.xsl'. -->
+   <!-- This file generated 2025-07-09T08:33:58Z by 'extract-isosch.xsl'. -->
    <!-- ********************* -->
    <!-- namespaces, declared: -->
    <!-- ********************* -->
@@ -154,12 +154,12 @@
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-28">
       <rule context="tei:rs[@type='letter'][@key]">
-         <assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
+         <assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-29">
       <rule context="tei:rs[@type='letters'][@key]">
-         <assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
+         <assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-30">

--- a/schema/de/wegaSourcesTEI.rng
+++ b/schema/de/wegaSourcesTEI.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-06-26T14:14:02Z. . 
+Schema generated from ODD source 2025-07-09T08:33:58Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -3350,7 +3350,7 @@ Empfohlene Werte sind: 1] spoken (spoken); 2] thought (thought); 3] written (wri
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3358,7 +3358,7 @@ Empfohlene Werte sind: 1] spoken (spoken); 2] thought (thought); 3] written (wri
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3519,7 +3519,7 @@ Empfohlene Werte sind: 1] spoken (spoken); 2] thought (thought); 3] written (wri
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>
@@ -5785,7 +5785,7 @@ Empfohlene Werte sind: 1] ISBN; 2] ISSN; 3] DOI; 4] URI; 5] VIAF; 6] ESTC; 7] OC
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/de/wegaThematicCommentaries.isosch
+++ b/schema/de/wegaThematicCommentaries.isosch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <title>ISO Schematron rules</title>
-   <!-- This file generated 2025-06-26T14:14:02Z by 'extract-isosch.xsl'. -->
+   <!-- This file generated 2025-07-09T08:34:07Z by 'extract-isosch.xsl'. -->
    <!-- ********************* -->
    <!-- namespaces, declared: -->
    <!-- ********************* -->
@@ -139,12 +139,12 @@
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-25">
       <rule context="tei:rs[@type='letter'][@key]">
-         <assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
+         <assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-26">
       <rule context="tei:rs[@type='letters'][@key]">
-         <assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
+         <assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-27">

--- a/schema/de/wegaThematicCommentaries.rng
+++ b/schema/de/wegaThematicCommentaries.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-06-26T14:14:02Z. . 
+Schema generated from ODD source 2025-07-09T08:34:07Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -2880,7 +2880,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2888,7 +2888,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3049,7 +3049,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>
@@ -5572,7 +5572,7 @@ Empfohlene Werte sind: 1] label; 2] data</a:documentation>
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/de/wegaVar.isosch
+++ b/schema/de/wegaVar.isosch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <title>ISO Schematron rules</title>
-   <!-- This file generated 2025-03-18T07:58:30Z by 'extract-isosch.xsl'. -->
+   <!-- This file generated 2025-07-09T08:34:15Z by 'extract-isosch.xsl'. -->
    <!-- ********************* -->
    <!-- namespaces, declared: -->
    <!-- ********************* -->
@@ -139,12 +139,12 @@
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-25">
       <rule context="tei:rs[@type='letter'][@key]">
-         <assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
+         <assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-26">
       <rule context="tei:rs[@type='letters'][@key]">
-         <assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
+         <assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-27">

--- a/schema/de/wegaVar.rng
+++ b/schema/de/wegaVar.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-06-26T14:14:03Z. . 
+Schema generated from ODD source 2025-07-09T08:34:15Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -2931,7 +2931,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2939,7 +2939,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3100,7 +3100,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>
@@ -5913,7 +5913,7 @@ Empfohlene Werte sind: 1] label; 2] data</a:documentation>
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/de/wegaWorks.isosch
+++ b/schema/de/wegaWorks.isosch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <title>ISO Schematron rules</title>
-   <!-- This file generated 2025-03-06T08:18:56Z by 'extract-isosch.xsl'. -->
+   <!-- This file generated 2025-07-09T08:34:26Z by 'extract-isosch.xsl'. -->
    <!-- ********************* -->
    <!-- namespaces, implicit: -->
    <!-- ********************* -->

--- a/schema/de/wegaWorks.rng
+++ b/schema/de/wegaWorks.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.music-encoding.org/ns/mei"><!--
-Schema generated from ODD source 2025-03-06T08:18:56Z. . 
+Schema generated from ODD source 2025-07-09T08:34:25Z. . 
 TEI Edition: Version 5.0 
 TEI Edition Location: https://www.tei-c.org/Vault/P5// 
   

--- a/schema/de/wegaWritings.isosch
+++ b/schema/de/wegaWritings.isosch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <title>ISO Schematron rules</title>
-   <!-- This file generated 2025-03-18T07:58:31Z by 'extract-isosch.xsl'. -->
+   <!-- This file generated 2025-07-09T08:34:25Z by 'extract-isosch.xsl'. -->
    <!-- ********************* -->
    <!-- namespaces, declared: -->
    <!-- ********************* -->
@@ -154,12 +154,12 @@
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-28">
       <rule context="tei:rs[@type='letter'][@key]">
-         <assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
+         <assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-29">
       <rule context="tei:rs[@type='letters'][@key]">
-         <assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
+         <assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-30">

--- a/schema/de/wegaWritings.rng
+++ b/schema/de/wegaWritings.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-06-26T14:14:04Z. . 
+Schema generated from ODD source 2025-07-09T08:34:25Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -3105,7 +3105,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3113,7 +3113,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3274,7 +3274,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>
@@ -5301,7 +5301,7 @@ Elements]</a:documentation>
                         <param name="pattern">A03\d{4}</param>
                      </data>
                      <data type="string">
-                        <param name="pattern">A04\d{4}</param>
+                        <param name="pattern">A04[0-9A-F]{4}</param>
                      </data>
                      <data type="string">
                         <param name="pattern">A10\d{4}</param>
@@ -6841,7 +6841,7 @@ Beispielwerte sind etwa: 1] glued; 2] pinned; 3] sewn</a:documentation>
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/de/wega_all.isosch
+++ b/schema/de/wega_all.isosch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <title>ISO Schematron rules</title>
-   <!-- This file generated 2025-03-18T07:58:30Z by 'extract-isosch.xsl'. -->
+   <!-- This file generated 2025-07-09T08:34:23Z by 'extract-isosch.xsl'. -->
    <!-- ********************* -->
    <!-- namespaces, declared: -->
    <!-- ********************* -->
@@ -159,12 +159,12 @@
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-29">
       <rule context="tei:rs[@type='letter'][@key]">
-         <assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
+         <assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-30">
       <rule context="tei:rs[@type='letters'][@key]">
-         <assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
+         <assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</assert>
       </rule>
    </pattern>
    <pattern id="schematron-constraint-rs-typeNkey-31">

--- a/schema/de/wega_all.rng
+++ b/schema/de/wega_all.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-03-18T07:58:30Z. . 
+Schema generated from ODD source 2025-07-09T08:34:23Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -3800,7 +3800,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3808,7 +3808,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3969,7 +3969,7 @@ Empfohlene Werte sind: 1] deprecationInfo (deprecation information)</a:documenta
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>
@@ -6702,7 +6702,7 @@ Empfohlene Werte sind: 1] sent; 2] received; 3] transmitted; 4] redirected; 5] f
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/en/wegaBiblio.rng
+++ b/schema/en/wegaBiblio.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-06-26T14:14:18Z. . 
+Schema generated from ODD source 2025-07-09T08:34:28Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -1621,7 +1621,7 @@ Suggested values include: 1] spoken (spoken); 2] thought (thought); 3] written (
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -1629,7 +1629,7 @@ Suggested values include: 1] spoken (spoken); 2] thought (thought); 3] written (
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -1790,7 +1790,7 @@ Suggested values include: 1] spoken (spoken); 2] thought (thought); 3] written (
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/en/wegaDiaries.rng
+++ b/schema/en/wegaDiaries.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-03-18T08:00:26Z. . 
+Schema generated from ODD source 2025-07-09T08:34:30Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -2715,7 +2715,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2723,7 +2723,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2884,7 +2884,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>
@@ -4730,7 +4730,7 @@ Sample values include: 1] glued; 2] pinned; 3] sewn</a:documentation>
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/en/wegaDocuments.rng
+++ b/schema/en/wegaDocuments.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-06-26T14:14:19Z. . 
+Schema generated from ODD source 2025-07-09T08:34:31Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -3166,7 +3166,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3174,7 +3174,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3335,7 +3335,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>
@@ -5392,7 +5392,7 @@ Suggested values include: 1] ISBN; 2] ISSN; 3] DOI; 4] URI; 5] VIAF; 6] ESTC; 7]
                         <param name="pattern">A03\d{4}</param>
                      </data>
                      <data type="string">
-                        <param name="pattern">A04\d{4}</param>
+                        <param name="pattern">A04[0-9A-F]{4}</param>
                      </data>
                      <data type="string">
                         <param name="pattern">A10\d{4}</param>
@@ -6957,7 +6957,7 @@ Sample values include: 1] glued; 2] pinned; 3] sewn</a:documentation>
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/en/wegaLetters.rng
+++ b/schema/en/wegaLetters.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-06-26T14:14:20Z. . 
+Schema generated from ODD source 2025-07-09T08:34:33Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -3305,7 +3305,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3313,7 +3313,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3474,7 +3474,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>
@@ -5696,7 +5696,7 @@ Suggested values include: 1] sent; 2] received; 3] transmitted; 4] redirected; 5
                         <param name="pattern">A03\d{4}</param>
                      </data>
                      <data type="string">
-                        <param name="pattern">A04\d{4}</param>
+                        <param name="pattern">A04[0-9A-F]{4}</param>
                      </data>
                      <data type="string">
                         <param name="pattern">A10\d{4}</param>
@@ -5710,7 +5710,7 @@ Suggested values include: 1] sent; 2] received; 3] transmitted; 4] redirected; 5
          <attribute name="xml:id">
             <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(identifier) provides a unique identifier for the element bearing the attribute.</a:documentation>
             <data type="string">
-               <param name="pattern">A04\d{4}</param>
+               <param name="pattern">A04[0-9A-F]{4}</param>
             </data>
          </attribute>
          <empty/>
@@ -7524,7 +7524,7 @@ Sample values include: 1] glued; 2] pinned; 3] sewn</a:documentation>
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/en/wegaNews.rng
+++ b/schema/en/wegaNews.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-03-18T08:00:29Z. . 
+Schema generated from ODD source 2025-07-09T08:34:34Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -2255,7 +2255,7 @@ Suggested values include: 1] spoken (spoken); 2] thought (thought); 3] written (
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2263,7 +2263,7 @@ Suggested values include: 1] spoken (spoken); 2] thought (thought); 3] written (
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2424,7 +2424,7 @@ Suggested values include: 1] spoken (spoken); 2] thought (thought); 3] written (
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/en/wegaOrgs.rng
+++ b/schema/en/wegaOrgs.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-03-18T08:00:29Z. . 
+Schema generated from ODD source 2025-07-09T08:34:35Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -2463,7 +2463,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       xmlns:xi="http://www.w3.org/2001/XInclude"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2472,7 +2472,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       xmlns:xi="http://www.w3.org/2001/XInclude"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2645,7 +2645,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>
@@ -4409,7 +4409,7 @@ Elements 7.2.5. Speech Contents]</a:documentation>
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/en/wegaPersons.rng
+++ b/schema/en/wegaPersons.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-03-18T08:00:30Z. . 
+Schema generated from ODD source 2025-07-09T08:34:36Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -2221,7 +2221,7 @@ Suggested values include: 1] spoken (spoken); 2] thought (thought); 3] written (
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2229,7 +2229,7 @@ Suggested values include: 1] spoken (spoken); 2] thought (thought); 3] written (
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2390,7 +2390,7 @@ Suggested values include: 1] spoken (spoken); 2] thought (thought); 3] written (
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/en/wegaPlaces.rng
+++ b/schema/en/wegaPlaces.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-06-26T14:14:22Z. . 
+Schema generated from ODD source 2025-07-09T08:34:36Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -2003,7 +2003,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2011,7 +2011,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2172,7 +2172,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/en/wegaSourcesTEI.rng
+++ b/schema/en/wegaSourcesTEI.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-06-26T14:14:23Z. . 
+Schema generated from ODD source 2025-07-09T08:34:37Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -3350,7 +3350,7 @@ Suggested values include: 1] spoken (spoken); 2] thought (thought); 3] written (
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3358,7 +3358,7 @@ Suggested values include: 1] spoken (spoken); 2] thought (thought); 3] written (
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3519,7 +3519,7 @@ Suggested values include: 1] spoken (spoken); 2] thought (thought); 3] written (
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>
@@ -5781,7 +5781,7 @@ Suggested values include: 1] ISBN; 2] ISSN; 3] DOI; 4] URI; 5] VIAF; 6] ESTC; 7]
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/en/wegaThematicCommentaries.rng
+++ b/schema/en/wegaThematicCommentaries.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-06-26T14:14:24Z. . 
+Schema generated from ODD source 2025-07-09T08:34:38Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -2880,7 +2880,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2888,7 +2888,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3049,7 +3049,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>
@@ -5568,7 +5568,7 @@ Suggested values include: 1] label; 2] data</a:documentation>
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/en/wegaVar.rng
+++ b/schema/en/wegaVar.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-06-26T14:14:25Z. . 
+Schema generated from ODD source 2025-07-09T08:34:39Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -2931,7 +2931,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -2939,7 +2939,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3100,7 +3100,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>
@@ -5909,7 +5909,7 @@ Suggested values include: 1] label; 2] data</a:documentation>
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/en/wegaWorks.rng
+++ b/schema/en/wegaWorks.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.music-encoding.org/ns/mei"><!--
-Schema generated from ODD source 2025-03-06T08:22:29Z. . 
+Schema generated from ODD source 2025-07-09T08:34:41Z. . 
 TEI Edition: Version 5.0 
 TEI Edition Location: https://www.tei-c.org/Vault/P5// 
   

--- a/schema/en/wegaWritings.rng
+++ b/schema/en/wegaWritings.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-06-26T14:14:27Z. . 
+Schema generated from ODD source 2025-07-09T08:34:40Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -3105,7 +3105,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3113,7 +3113,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3274,7 +3274,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>
@@ -5296,7 +5296,7 @@ Elements]</a:documentation>
                         <param name="pattern">A03\d{4}</param>
                      </data>
                      <data type="string">
-                        <param name="pattern">A04\d{4}</param>
+                        <param name="pattern">A04[0-9A-F]{4}</param>
                      </data>
                      <data type="string">
                         <param name="pattern">A10\d{4}</param>
@@ -6834,7 +6834,7 @@ Sample values include: 1] glued; 2] pinned; 3] sewn</a:documentation>
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/schema/en/wega_all.rng
+++ b/schema/en/wega_all.rng
@@ -5,7 +5,7 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2025-03-18T08:00:33Z. . 
+Schema generated from ODD source 2025-07-09T08:34:39Z. . 
 TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
 TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
   
@@ -3800,7 +3800,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letter'][@key]">
-               <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3808,7 +3808,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                       xmlns:s="http://www.ascc.net/xml/schematron"
                       xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                       context="tei:rs[@type='letters'][@key]">
-               <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+               <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
             </sch:rule>
             <sch:rule xmlns="http://www.tei-c.org/ns/1.0"
                       xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -3969,7 +3969,7 @@ Suggested values include: 1] deprecationInfo (deprecation information)</a:docume
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>
@@ -6695,7 +6695,7 @@ Suggested values include: 1] sent; 2] received; 3] transmitted; 4] redirected; 5
                            <param name="pattern">A03\d{4}</param>
                         </data>
                         <data type="string">
-                           <param name="pattern">A04\d{4}</param>
+                           <param name="pattern">A04[0-9A-F]{4}</param>
                         </data>
                         <data type="string">
                            <param name="pattern">A05\d{4}</param>

--- a/src/Specs/common-specs.odd.xml
+++ b/src/Specs/common-specs.odd.xml
@@ -100,7 +100,7 @@
             <desc xml:lang="de" versionDate="2017-08-29">definiert das Muster für Brief-IDs innerhalb der WeGA</desc>
             <desc xml:lang="en" versionDate="2017-08-29">defines the possible attribute values for letter IDs within the WeGA</desc>
             <content>
-                <dataRef name="string" restriction="A04\d{4}"/>
+                <dataRef name="string" restriction="A04[0-9A-F]{4}"/>
             </content>
         </dataSpec>
         
@@ -1883,10 +1883,10 @@
                         <sch:assert test="matches(@key, '^(A03\d{4}\s)*A03\d{4}$')">A type value of 'writings' must have at least one key, each starting with 'A03'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letter'][@key]">
-                        <sch:assert test="matches(@key, '^A04\d{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^A04[0-9A-F]{4}$')">A type value of 'letter' must have only one key, starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='letters'][@key]">
-                        <sch:assert test="matches(@key, '^(A04\d{4}\s)*A04\d{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
+                        <sch:assert test="matches(@key, '^(A04[0-9A-F]{4}\s)*A04[0-9A-F]{4}$')">A type value of 'letters' must have at least one key, each starting with 'A04'</sch:assert>
                     </sch:rule>
                     <sch:rule context="tei:rs[@type='news'][@key]">
                         <sch:assert test="matches(@key, '^(A05\d{4}\s)*A05\d{4}$')">A type value of 'news' must have at least one key, starting with 'A05'</sch:assert>


### PR DESCRIPTION
Apart from the schema I didn't make any changes to the WebApp.
-> The WeGA-document-type in options.xml has already been adjusted to include hexadecimal numberin for all entity types.
-> In the controller and wdt modules, nothing hardcoded was found

Also in the tests I couldn't find anything to change.
-> The create-includesfiles.xsl is already set to include hexadecimal filenames for all data types
-> The other tests seem to validate depending on the ODD schema